### PR TITLE
Fix compilation error.

### DIFF
--- a/CodeFormatServer/src/Protocol/ProtocolBuffer.cpp
+++ b/CodeFormatServer/src/Protocol/ProtocolBuffer.cpp
@@ -1,5 +1,6 @@
 #include "CodeFormatServer/Protocol/ProtocolBuffer.h"
 #include <cstring>
+#include <algorithm>
 
 ProtocolBuffer::ProtocolBuffer(std::size_t capacity)
 	: _writeIndex(0),


### PR DESCRIPTION
Fixes compilation error:

```
/projects/cpp/EmmyLuaCodeStyle/CodeFormatServer/src/Protocol/ProtocolBuffer.cpp: In member function ‘void ProtocolBuffer::Reset()’:
/projects/cpp/EmmyLuaCodeStyle/CodeFormatServer/src/Protocol/ProtocolBuffer.cpp:68:22: error: ‘copy_n’ is not a member of ‘std’; did you mean ‘copy’?
   68 |                 std::copy_n(_textProtocol.data() + doneIndex, _writeIndex - doneIndex, _textProtocol.data());
      |                      ^~~~~~
      |                      copy
make[2]: *** [CodeFormatServer/CMakeFiles/CodeFormatServer.dir/build.make:188: CodeFormatServer/CMakeFiles/CodeFormatServer.dir/src/Protocol/ProtocolBuffer.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:344: CodeFormatServer/CMakeFiles/CodeFormatServer.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```