### PR TITLE
fix CodeFormat CLI to allow reading from stdin

### DIFF
--- a/CodeFormat/src/CodeFormat.cpp
+++ b/CodeFormat/src/CodeFormat.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv)
 		return -1;
 	}
 
-	if (cmd.HasOption("file"))
+	if (cmd.HasOption("file") || cmd.HasOption("stdin"))
 	{
 		auto luaFormat = std::make_shared<LuaFormat>();
 		if (cmd.HasOption("file"))

--- a/CodeFormat/src/CodeFormat.cpp
+++ b/CodeFormat/src/CodeFormat.cpp
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
 	   .Add<bool>("overwrite", "ow", "Format overwrite the input file")
 	   .Add<std::string>("workspace", "w",
 	                     "Specify workspace directory,if no input file is specified, bulk formatting is performed")
-	   .Add<int>("stdin", "i", "Read from stdin and specify read size")
+	   .Add<bool>("stdin", "i", "Read from stdin and specify read size")
 	   .Add<std::string>("config", "c",
 	                     "Specify .editorconfig file, it decides on the effect of formatting")
 	   .Add<bool>("detect-config", "d",
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
 	if (cmd.HasOption("file") || cmd.HasOption("stdin"))
 	{
 		auto luaFormat = std::make_shared<LuaFormat>();
-		if (cmd.HasOption("file"))
+		if (cmd.HasOption("file") && !cmd.HasOption("stdin"))
 		{
 			if (!luaFormat->SetInputFile(cmd.Get<std::string>("file")))
 			{
@@ -95,18 +95,17 @@ int main(int argc, char** argv)
 				return -1;
 			}
 		}
-		else if (cmd.HasOption("stdin"))
+		else if (cmd.HasOption("stdin") && !cmd.HasOption("file"))
 		{
 			SET_BINARY_MODE();
-			std::size_t size = cmd.Get<int>("stdin");
-			if (!luaFormat->ReadFromStdin(size))
+			if (!luaFormat->ReadFromStdin())
 			{
 				return -1;
 			}
 		}
 		else
 		{
-			std::cerr << "not special input file" << std::endl;
+			std::cerr << "Either --file or --stdin must be specified." << std::endl;
 			return -1;
 		}
 

--- a/CodeFormat/src/LuaFormat.cpp
+++ b/CodeFormat/src/LuaFormat.cpp
@@ -23,14 +23,11 @@ bool LuaFormat::SetInputFile(std::string_view input)
 	return _parser != nullptr;
 }
 
-bool LuaFormat::ReadFromStdin(std::size_t size)
+bool LuaFormat::ReadFromStdin()
 {
-	std::string buffer;
-	buffer.resize(size);
-	std::cin.get(buffer.data(), size, EOF);
-	auto realSize = strnlen(buffer.data(), size);
-	buffer.resize(realSize);
-	_parser = LuaParser::LoadFromBuffer(std::move(buffer));
+	std::stringstream buffer;
+	buffer << std::cin.rdbuf();
+	_parser = LuaParser::LoadFromBuffer(std::move(buffer.str()));
 	return _parser != nullptr;
 }
 

--- a/CodeFormat/src/LuaFormat.h
+++ b/CodeFormat/src/LuaFormat.h
@@ -17,7 +17,7 @@ public:
 
 	bool SetInputFile(std::string_view input);
 
-	bool ReadFromStdin(std::size_t size);
+	bool ReadFromStdin();
 
 	void SetOutputFile(std::string_view path);
 


### PR DESCRIPTION
Now it is possible to format Lua code from stdin:

``` shell
cat somefile.lua | CodeFormat format --config $(pwd)/.editorconfig --stdin 8192
```