### PR TITLE
Fix missing backslashes in name-style docs

### DIFF
--- a/docs/name_style.md
+++ b/docs/name_style.md
@@ -72,7 +72,7 @@
 ```json
 "local_name_style": {
     "type" : "pattern",
-    "param": "m_(w+)",
+    "param": "m_(\\w+)",
     "$1": "camel_case"
 }
 ```
@@ -88,7 +88,7 @@
     "camel_case",
     {
         "type" : "pattern",
-        "param": "m_(w+)",
+        "param": "m_(\\w+)",
         "$1": "camel_case"
     }
 ]

--- a/docs/name_style_EN.md
+++ b/docs/name_style_EN.md
@@ -72,7 +72,7 @@ Regular expressions support capture groups and then match basic nomenclature:
 ```json
 "local_name_style": {
      "type" : "pattern",
-     "param": "m_(w+)",
+     "param": "m_(\\w+)",
      "$1": "camel_case"
 }
 ```
@@ -88,7 +88,7 @@ Where `"$1": "camel_case"` means that the content of the first capture group nee
      "camel_case",
      {
          "type" : "pattern",
-         "param": "m_(w+)",
+         "param": "m_(\\w+)",
          "$1": "camel_case"
      }
 ]


### PR DESCRIPTION
When trying to configure name-style configurations with RegEx patterns, I encountered that the samples in the documentation don't work as expected due to missing backslashes, which are added in this PR.