### PR TITLE
Improve Formatter for Semicolon Rule

### DIFF
--- a/CodeFormatCore/include/CodeFormatCore/Config/LuaStyleEnum.h
+++ b/CodeFormatCore/include/CodeFormatCore/Config/LuaStyleEnum.h
@@ -87,7 +87,7 @@ enum class AlignChainExpr {
 
 enum class EndStmtWithSemicolon {
     Keep,
-    ReplaceWithLinebreak,
+    ReplaceWithNewline,
     Always,
     SameLine
 };

--- a/CodeFormatCore/include/CodeFormatCore/Config/LuaStyleEnum.h
+++ b/CodeFormatCore/include/CodeFormatCore/Config/LuaStyleEnum.h
@@ -87,7 +87,7 @@ enum class AlignChainExpr {
 
 enum class EndStmtWithSemicolon {
     Keep,
-    Never,
+    ReplaceWithLinebreak,
     Always,
     SameLine
 };

--- a/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
+++ b/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
@@ -18,6 +18,7 @@ public:
 private:
     void AddSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
     void InsertNewLineBeforeNode(LuaSyntaxNode n, const LuaSyntaxTree &t);
+    void InsertNewLineBeforeNextNode(LuaSyntaxNode n, const LuaSyntaxTree& t);
     void RemoveSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool IsFirstStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool IsLastStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t);

--- a/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
+++ b/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
@@ -17,10 +17,8 @@ public:
 
 private:
     void AddSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
-    void InsertNewLineBeforeNode(LuaSyntaxNode n, const LuaSyntaxTree &t);
     void InsertNewLineBeforeNextNode(LuaSyntaxNode n, const LuaSyntaxTree& t);
     void RemoveSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
-    bool IsFirstStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool IsLastStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool EndsWithSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool ContainsSemicolon(LuaSyntaxNode n, const LuaSyntaxTree& t);

--- a/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
+++ b/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
@@ -17,11 +17,11 @@ public:
 
 private:
     void AddSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
-    void InsertNewLineBeforeNextNode(LuaSyntaxNode n, const LuaSyntaxTree& t);
+    void InsertNewLineBeforeNextNode(LuaSyntaxNode n, const LuaSyntaxTree &t);
     void RemoveSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool IsLastStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool EndsWithSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
-    bool ContainsSemicolon(LuaSyntaxNode n, const LuaSyntaxTree& t);
+    bool ContainsSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
     LuaSyntaxNode GetLastNonCommentToken(LuaSyntaxNode n, const LuaSyntaxTree &t);
 
     std::unordered_map<std::size_t, SemicolonStrategy> _semicolon;

--- a/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
+++ b/CodeFormatCore/include/CodeFormatCore/Format/Analyzer/SemicolonAnalyzer.h
@@ -22,6 +22,7 @@ private:
     bool IsFirstStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool IsLastStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t);
     bool EndsWithSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t);
+    bool ContainsSemicolon(LuaSyntaxNode n, const LuaSyntaxTree& t);
     LuaSyntaxNode GetLastNonCommentToken(LuaSyntaxNode n, const LuaSyntaxTree &t);
 
     std::unordered_map<std::size_t, SemicolonStrategy> _semicolon;

--- a/CodeFormatCore/src/Config/LuaStyle.cpp
+++ b/CodeFormatCore/src/Config/LuaStyle.cpp
@@ -293,8 +293,8 @@ void LuaStyle::Parse(std::map<std::string, std::string, std::less<>> &configMap)
             end_statement_with_semicolon = EndStmtWithSemicolon::Keep;
         } else if (configMap.at("end_statement_with_semicolon") == "always") {
             end_statement_with_semicolon = EndStmtWithSemicolon::Always;
-        } else if (configMap.at("end_statement_with_semicolon") == "replace_with_linebreak") {
-            end_statement_with_semicolon = EndStmtWithSemicolon::ReplaceWithLinebreak;
+        } else if (configMap.at("end_statement_with_semicolon") == "replace_with_newline") {
+            end_statement_with_semicolon = EndStmtWithSemicolon::ReplaceWithNewline;
         } else if (configMap.at("end_statement_with_semicolon") == "same_line") {
             end_statement_with_semicolon = EndStmtWithSemicolon::SameLine;
         }

--- a/CodeFormatCore/src/Config/LuaStyle.cpp
+++ b/CodeFormatCore/src/Config/LuaStyle.cpp
@@ -293,8 +293,8 @@ void LuaStyle::Parse(std::map<std::string, std::string, std::less<>> &configMap)
             end_statement_with_semicolon = EndStmtWithSemicolon::Keep;
         } else if (configMap.at("end_statement_with_semicolon") == "always") {
             end_statement_with_semicolon = EndStmtWithSemicolon::Always;
-        } else if (configMap.at("end_statement_with_semicolon") == "never") {
-            end_statement_with_semicolon = EndStmtWithSemicolon::Never;
+        } else if (configMap.at("end_statement_with_semicolon") == "replace_with_linebreak") {
+            end_statement_with_semicolon = EndStmtWithSemicolon::ReplaceWithLinebreak;
         } else if (configMap.at("end_statement_with_semicolon") == "same_line") {
             end_statement_with_semicolon = EndStmtWithSemicolon::SameLine;
         }

--- a/CodeFormatCore/src/Diagnostic/CodeStyle/CodeStyleChecker.cpp
+++ b/CodeFormatCore/src/Diagnostic/CodeStyle/CodeStyleChecker.cpp
@@ -96,7 +96,7 @@ void CodeStyleChecker::BasicResolve(LuaSyntaxNode syntaxNode, const LuaSyntaxTre
             }
             case TokenStrategy::StmtEndSemicolon: {
                 switch (d.GetState().GetStyle().end_statement_with_semicolon) {
-                    case EndStmtWithSemicolon::ReplaceWithLinebreak: {
+                    case EndStmtWithSemicolon::ReplaceWithNewline: {
                         d.PushDiagnostic(DiagnosticType::Semicolon, textRange,
                                          LText("expected statement not to end with ;"));
                         break;

--- a/CodeFormatCore/src/Diagnostic/CodeStyle/CodeStyleChecker.cpp
+++ b/CodeFormatCore/src/Diagnostic/CodeStyle/CodeStyleChecker.cpp
@@ -96,7 +96,7 @@ void CodeStyleChecker::BasicResolve(LuaSyntaxNode syntaxNode, const LuaSyntaxTre
             }
             case TokenStrategy::StmtEndSemicolon: {
                 switch (d.GetState().GetStyle().end_statement_with_semicolon) {
-                    case EndStmtWithSemicolon::Never: {
+                    case EndStmtWithSemicolon::ReplaceWithLinebreak: {
                         d.PushDiagnostic(DiagnosticType::Semicolon, textRange,
                                          LText("expected statement not to end with ;"));
                         break;

--- a/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
@@ -25,7 +25,7 @@ void SemicolonAnalyzer::Analyze(FormatState &f, const LuaSyntaxTree &t) {
                         }
                         break;
                     }
-                    case EndStmtWithSemicolon::Never: {
+                    case EndStmtWithSemicolon::ReplaceWithLinebreak: {
                         // no action needed when there's no semicolons at all!
                         if (ContainsSemicolon(syntaxNode, t)) {
                             if (EndsWithSemicolon(syntaxNode, t)) {

--- a/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
@@ -113,7 +113,7 @@ bool SemicolonAnalyzer::EndsWithSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &
 }
 
 bool SemicolonAnalyzer::ContainsSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t) {
-    return n.GetChildTokens(';', t).size() > 0;
+    return n.GetChildToken(';', t).IsToken(t);
 }
 
 LuaSyntaxNode SemicolonAnalyzer::GetLastNonCommentToken(LuaSyntaxNode n, const LuaSyntaxTree &t) {

--- a/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
@@ -2,7 +2,6 @@
 #include "CodeFormatCore/Config/LuaStyleEnum.h"
 #include "CodeFormatCore/Format/FormatState.h"
 #include "LuaParser/Lexer/LuaTokenTypeDetail.h"
-#include <iostream>
 
 SemicolonAnalyzer::SemicolonAnalyzer() {
 }
@@ -18,7 +17,7 @@ void SemicolonAnalyzer::Analyze(FormatState &f, const LuaSyntaxTree &t) {
                 switch (f.GetStyle().end_statement_with_semicolon) {
                     case EndStmtWithSemicolon::Always: {
                         if (syntaxNode.GetSyntaxKind(t) == LuaSyntaxNodeKind::LabelStatement) {
-                            break; // labels should not end with semicolons
+                            break;// labels should not end with semicolons
                         }
                         if (!EndsWithSemicolon(syntaxNode, t)) {
                             AddSemicolon(syntaxNode, t);
@@ -83,7 +82,7 @@ void SemicolonAnalyzer::AddSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t) {
     }
 }
 
-void SemicolonAnalyzer::InsertNewLineBeforeNextNode(LuaSyntaxNode n, const LuaSyntaxTree& t) {
+void SemicolonAnalyzer::InsertNewLineBeforeNextNode(LuaSyntaxNode n, const LuaSyntaxTree &t) {
     auto token = n.GetNextTokenSkipComment(t);
     if (token.IsToken(t) && token.GetStartLine(t) == n.GetEndLine(t)) {
         _semicolon[token.GetIndex()] = SemicolonStrategy::InsertNewLine;
@@ -113,7 +112,7 @@ bool SemicolonAnalyzer::EndsWithSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &
     return token.GetTokenKind(t) == ';';
 }
 
-bool SemicolonAnalyzer::ContainsSemicolon(LuaSyntaxNode n, const LuaSyntaxTree& t) {
+bool SemicolonAnalyzer::ContainsSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t) {
     return n.GetChildTokens(';', t).size() > 0;
 }
 

--- a/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
@@ -25,7 +25,7 @@ void SemicolonAnalyzer::Analyze(FormatState &f, const LuaSyntaxTree &t) {
                         }
                         break;
                     }
-                    case EndStmtWithSemicolon::ReplaceWithLinebreak: {
+                    case EndStmtWithSemicolon::ReplaceWithNewline: {
                         // no action needed when there's no semicolons at all!
                         if (ContainsSemicolon(syntaxNode, t)) {
                             if (EndsWithSemicolon(syntaxNode, t)) {

--- a/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/SemicolonAnalyzer.cpp
@@ -83,13 +83,6 @@ void SemicolonAnalyzer::AddSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t) {
     }
 }
 
-void SemicolonAnalyzer::InsertNewLineBeforeNode(LuaSyntaxNode n, const LuaSyntaxTree &t) {
-    auto token = n.GetFirstToken(t); // line breaks are put in front of the statement itself by non-first statements
-    if (token.IsToken(t)) {
-        _semicolon[token.GetIndex()] = SemicolonStrategy::InsertNewLine;
-    }
-}
-
 void SemicolonAnalyzer::InsertNewLineBeforeNextNode(LuaSyntaxNode n, const LuaSyntaxTree& t) {
     auto token = n.GetNextTokenSkipComment(t);
     if (token.IsToken(t) && token.GetStartLine(t) == n.GetEndLine(t)) {
@@ -103,7 +96,6 @@ void SemicolonAnalyzer::RemoveSemicolon(LuaSyntaxNode n, const LuaSyntaxTree &t)
         _semicolon[token.GetIndex()] = SemicolonStrategy::Remove;
     }
 }
-
 
 bool SemicolonAnalyzer::IsLastStmtOfLine(LuaSyntaxNode n, const LuaSyntaxTree &t) {
     // check if next stmt starts on same line as the current one ends

--- a/Test/src/FormatStyle_unitest.cpp
+++ b/Test/src/FormatStyle_unitest.cpp
@@ -1634,6 +1634,8 @@ for i, v in ipairs(values) do
     end;
 end;
 local table1 = { 1, 2, 3 }
+local opts = { on_exit = function() job = nil end }
+local opts = { on_exit = function() job = nil; end };
 )",
             R"(
 local func = testFunc
@@ -1649,6 +1651,9 @@ for i, v in ipairs(values) do
     end
 end
 local table1 = { 1, 2, 3 }
+local opts = { on_exit = function() job = nil end }
+local opts = { on_exit = function() job = nil
+end }
 )",
             style));
 

--- a/Test/src/FormatStyle_unitest.cpp
+++ b/Test/src/FormatStyle_unitest.cpp
@@ -1621,7 +1621,7 @@ local table1 = { 1, 2, 3 };
 )",
             style));
 
-    style.end_statement_with_semicolon = EndStmtWithSemicolon::ReplaceWithLinebreak;
+    style.end_statement_with_semicolon = EndStmtWithSemicolon::ReplaceWithNewline;
     EXPECT_TRUE(TestHelper::TestFormatted(
             R"(
 local func = testFunc; print(type(nil)); -- nil;

--- a/Test/src/FormatStyle_unitest.cpp
+++ b/Test/src/FormatStyle_unitest.cpp
@@ -1621,7 +1621,7 @@ local table1 = { 1, 2, 3 };
 )",
             style));
 
-    style.end_statement_with_semicolon = EndStmtWithSemicolon::Never;
+    style.end_statement_with_semicolon = EndStmtWithSemicolon::ReplaceWithLinebreak;
     EXPECT_TRUE(TestHelper::TestFormatted(
             R"(
 local func = testFunc; print(type(nil)); -- nil;

--- a/docs/format_config.md
+++ b/docs/format_config.md
@@ -538,5 +538,5 @@ end_statement_with_semicolon
     每条语句都应该以分号结束，缺失的分号将被添加。
 - same_line
     单行中的多个语句可以用必要的分号分隔，但可选的分号将被移除
-- never
+- replace_with_linebreak
     任何语句都不能以分号结束，语句末尾的所有分号都将被移除，包含多个语句的行将被分隔成多行

--- a/docs/format_config.md
+++ b/docs/format_config.md
@@ -538,5 +538,5 @@ end_statement_with_semicolon
     每条语句都应该以分号结束，缺失的分号将被添加。
 - same_line
     单行中的多个语句可以用必要的分号分隔，但可选的分号将被移除
-- replace_with_linebreak
+- replace_with_newline
     任何语句都不能以分号结束，语句末尾的所有分号都将被移除，包含多个语句的行将被分隔成多行

--- a/docs/format_config_EN.md
+++ b/docs/format_config_EN.md
@@ -535,5 +535,5 @@ The possible values are:
     every statement should end with semicolon, missing semicolons will be added
 - same_line
     multiple statements in a single line may be separated by necessary semicolons, but optional semicolons will be removed
-- replace_with_linebreak
+- replace_with_newline
     no statement should end with semicolon, all semicolons at the end of statements will be removed, lines with multiple statements will be separated into multiple lines

--- a/docs/format_config_EN.md
+++ b/docs/format_config_EN.md
@@ -535,5 +535,5 @@ The possible values are:
     every statement should end with semicolon, missing semicolons will be added
 - same_line
     multiple statements in a single line may be separated by necessary semicolons, but optional semicolons will be removed
-- never
+- replace_with_linebreak
     no statement should end with semicolon, all semicolons at the end of statements will be removed, lines with multiple statements will be separated into multiple lines


### PR DESCRIPTION
Adressing #136
This PR improves the SemicolonAnalyzer in cases when semicolons are to be replaced with newlines (formerly option `never`) and renames the option to `replace_with_newline` to be more self-explanatory

New behavior:
- there's no reformatting at all when there are no semicolons (as that is fully unexpected)
- linebreaks will only be inserted when there was a semicolon previously (previous behavior was source of the above mentioned issue in that case), the reported issue would not happen anymore
- the option to enable this behavior is now named `replace_with_newline` to avoid wrong expectations

Not changed:
- when there was weird formatting left behind after the SemicolonAnalyzer, another formatting-run will change the result again, but not initiated by the SemicolonAnalyzer (e.g. fixing indents)
- behavior on previously tested code combinations

Also, this PR does not include a "new" `never` option we discussed, as simply deleting semicolons out of lines may lead to syntax errors or semantic issues, which one probably does not wish from a formatter. If they are automatically fixed by another formatting run, the result is likely the same as using `replace_with_newline`.

