### PR TITLE
Use ubuntu-20.04 in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-latest, target: linux, platform: linux-x64,}
+          - { os: ubuntu-20.04, target: linux, platform: linux-x64,}
           - { os: macos-latest, target: darwin, platform: darwin-x64,}
           - { os: macos-latest, target: darwin, platform: darwin-arm64}
           - { os: windows-latest, target: windows, platform: win32-x64 }


### PR DESCRIPTION
This should improve the compatibility of the Linux binaries. Otherwise with the current release I currently get the error:
```
linux-x64/bin/CodeFormat: /usr/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by linux-x64/bin/CodeFormat)
linux-x64/bin/CodeFormat: /usr/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by linux-x64/bin/CodeFormat)
linux-x64/bin/CodeFormat: /usr/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by linux-x64/bin/CodeFormat)
```