### PR TITLE
Add additional namestyle configuration for const variables

### DIFF
--- a/CodeFormatCore/include/CodeFormatCore/Config/LuaDiagnosticStyle.h
+++ b/CodeFormatCore/include/CodeFormatCore/Config/LuaDiagnosticStyle.h
@@ -44,4 +44,8 @@ public:
     std::vector<NameStyleRule> class_name_style = {
             NameStyleRule(NameStyleType::SnakeCase),
             NameStyleRule(NameStyleType::PascalCase)};
+
+    std::vector<NameStyleRule> const_variable_name_style = {
+            NameStyleRule(NameStyleType::SnakeCase),
+            NameStyleRule(NameStyleType::UpperSnakeCase)};
 };

--- a/CodeFormatCore/include/CodeFormatCore/Diagnostic/NameStyle/NameDefineType.h
+++ b/CodeFormatCore/include/CodeFormatCore/Diagnostic/NameStyle/NameDefineType.h
@@ -10,6 +10,7 @@ enum class NameDefineType {
     ImportModuleName,
     ModuleDefineName,
     TableFieldDefineName,
+    ConstVariableName
 };
 
 struct NameStyleInfo {

--- a/docs/name_style.md
+++ b/docs/name_style.md
@@ -30,6 +30,7 @@
 * module_name_style
 * require_module_name_style
 * class_name_style
+* const_variable_name_style
 
 每一个可配置项的格式都是相同的, 每个可配置项可配置的值支持如下格式:
 * 单字符串 例如: 

--- a/docs/name_style_EN.md
+++ b/docs/name_style_EN.md
@@ -30,6 +30,7 @@ The configurable items are:
 * module_name_style
 * require_module_name_style
 * class_name_style
+* const_variable_name_style
 
 The format of each configurable item is the same, and the configurable value of each configurable item supports the following formats:
 * Single string Example:


### PR DESCRIPTION
This PR adds a name style configuration option for variables marked with the attribute `<const>`, as described in https://github.com/CppCXY/EmmyLuaCodeStyle/issues/158

How it's designed:

- Configuration item `const_variable_name_style`
- "Special variables" like `ImportModuleName` and `ModuleName` are not affected
- Local variables with the attribute `<const>` are affected
- The default configuration is set that `SnakeCase` and `UpperSnakeCase` are allowed, so it should not affect existing code bases using the default name style configuration. If preferred, we could also set it to `Ignore` as the default, but as the name styles themselves are still quite recent, I wouldn't assume it would annoy people.

