### PR TITLE
Fix: short comment following long comment close

### DIFF
--- a/CodeFormatCore/src/Format/Analyzer/LineBreakAnalyzer.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/LineBreakAnalyzer.cpp
@@ -3,7 +3,6 @@
 #include "CodeFormatCore/Format/FormatState.h"
 #include "LuaParser/Lexer/LuaTokenTypeDetail.h"
 #include <algorithm>
-#include <cstdio>
 
 using NodeKind = LuaSyntaxNodeKind;
 
@@ -114,6 +113,7 @@ void LineBreakAnalyzer::ComplexAnalyze(FormatState &f, const LuaSyntaxTree &t) {
                                     if (nextToken == TK_SHORT_COMMENT) {
                                         break;
                                     }
+                                    // Fall through
                                 }
                                 case TK_SHORT_COMMENT:
                                 case TK_SHEBANG: {

--- a/CodeFormatCore/src/Format/Analyzer/LineBreakAnalyzer.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/LineBreakAnalyzer.cpp
@@ -3,6 +3,7 @@
 #include "CodeFormatCore/Format/FormatState.h"
 #include "LuaParser/Lexer/LuaTokenTypeDetail.h"
 #include <algorithm>
+#include <cstdio>
 
 using NodeKind = LuaSyntaxNodeKind;
 
@@ -107,8 +108,14 @@ void LineBreakAnalyzer::ComplexAnalyze(FormatState &f, const LuaSyntaxTree &t) {
 
                         } else {
                             switch (stmt.GetTokenKind(t)) {
-                                case TK_SHORT_COMMENT:
                                 case TK_LONG_COMMENT:
+                                {
+                                    auto nextToken = stmt.GetNextToken(t).GetTokenKind(t);
+                                    if (nextToken == TK_SHORT_COMMENT) {
+                                        break;
+                                    }
+                                }
+                                case TK_SHORT_COMMENT:
                                 case TK_SHEBANG: {
                                     BreakAfter(stmt, t, style.line_space_after_comment);
                                     break;

--- a/Test/src/FormatResult_unitest.cpp
+++ b/Test/src/FormatResult_unitest.cpp
@@ -1147,3 +1147,31 @@ only_latin = {
 }
 )", style));
 }
+
+TEST(Format, issue_170) {
+    EXPECT_TRUE(TestHelper::TestFormatted(
+            R"(
+--[[]]
+)",
+            R"(
+--[[]]
+)"));
+    EXPECT_TRUE(TestHelper::TestFormatted(
+            R"(
+--[[]]--
+)",
+            R"(
+--[[]] --
+)"));
+    EXPECT_TRUE(TestHelper::TestFormatted(
+            R"(
+--[[-----------
+
+]]-------------
+)",
+            R"(
+--[[-----------
+
+]] -------------
+)"));
+}


### PR DESCRIPTION
Makes short comment immediately following long comment not add a linebreak. No longer incorrectly indents.

Fixes #170

Before: `--[[]]--`  -> `--[[]]\n    --` -> `--[[]]\n--`
After: `--[[]]--` -> `--[[]] --`

