### PR TITLE
Parse namestyle configuration for `const_variable_name_style`

### DIFF
--- a/CodeFormatCore/src/Config/LuaDiagnosticStyle.cpp
+++ b/CodeFormatCore/src/Config/LuaDiagnosticStyle.cpp
@@ -104,7 +104,8 @@ void LuaDiagnosticStyle::ParseTree(InfoTree &tree) {
             {global_variable_name_style, "global_variable_name_style"},
             {module_name_style,          "module_name_style"         },
             {require_module_name_style,  "require_module_name_style" },
-            {class_name_style,           "class_name_style"          }
+            {class_name_style,           "class_name_style"          },
+            {const_variable_name_style,  "const_variable_name_style" }
     };
     for (auto &pair: name_styles) {
         if (auto n = root.GetValue(pair.second); !n.IsNull()) {


### PR DESCRIPTION
I am currently working on another name style rule, during which I noticed that any custom configuration of `const_variable_name_style` is not applied due to this missing line.

This PR resolves that problem.