### PR TITLE
Add codesamples for namestyles to docs

### DIFF
--- a/docs/name_style.md
+++ b/docs/name_style.md
@@ -96,3 +96,141 @@
 ]
 ```
 
+## 可配置项示例
+
+以下列表显示了每个可配置项针对的元素，并提供了一个小代码示例，同时列出了默认配置。
+
+### `local_name_style`
+
+> 默认值：`snake_case`
+
+在以下示例中，检查的名称是 `result`。请注意，由于作用域的原因，`some_value` 是由 `module_local_name_style` 检查的。
+
+```Lua
+local some_value = 42
+
+local function sum(first_value, second_value)
+    local result = first_value + second_value
+    return result
+end
+```
+
+### `function_param_name_style`
+
+> 默认值：`snake_case`
+
+在以下示例中，检查的名称是 `first_value` 和 `second_value`。
+
+```Lua
+local function sum(first_value, second_value)
+    local result = first_value + second_value
+    return result
+end
+```
+
+### `function_name_style`
+
+> 默认值：`snake_case`
+
+在以下示例中，检查的名称是 `some_action`。
+
+```Lua
+function some_action() 
+    return 0
+end
+```
+
+### `local_function_name_style`
+
+> 默认值：`snake_case`
+
+在以下示例中，检查的名称是 `calculate_square`。
+
+```Lua
+local function calculate_square(x)
+  return x * x
+end
+```
+
+### `table_field_name_style`
+
+> 默认值：`snake_case`
+
+在以下示例中，检查的名称是 `first_name` 和 `last_name`。
+
+```Lua
+local person = {}
+person.first_name = "John"
+person.last_name = "Doe"
+```
+
+### `global_variable_name_style`
+
+> 默认值：`snake_case` 和 `upper_snake_case`
+
+在以下示例中，检查的名称是 `MAX_ELEMENTS`。
+
+```Lua
+MAX_ELEMENTS = 100
+```
+
+### `module_name_style`
+
+> 默认值：`snake_case`
+
+在以下示例中，检查的名称是 `my_module`。
+
+```Lua
+local my_module = {}
+
+-- [...]
+
+return my_module
+```
+
+### `require_module_name_style`
+
+> 默认值：`snake_case` 和 `pascal_case`
+
+在以下示例中，检查的名称是 `util_module`。
+
+```Lua
+local util_module = require("util_module")
+local data_module = import("data_module")
+```
+
+### `class_name_style`
+
+> 默认值：`snake_case` 和 `pascal_case`
+
+在以下示例中，检查的名称是 `person`。
+
+```Lua
+local person = Class()
+```
+
+### `const_variable_name_style`
+
+> 默认值：`snake_case` 和 `upper_snake_case`
+
+在以下示例中，检查的名称是 `PI`。
+
+```Lua
+local PI <const> = 3.14
+```
+
+### `module_local_name_style`
+
+> 默认值：回退到当前的 `local_name_style` 配置
+
+在以下示例中，检查的名称是 `some_value` 和 `data`。
+
+```Lua
+local some_value = 42
+local data = {}
+
+local function sum(first_value, second_value)
+    local result = first_value + second_value
+    return result
+end
+```

--- a/docs/name_style_EN.md
+++ b/docs/name_style_EN.md
@@ -7,9 +7,9 @@ Naming style checking supports checking based on basic nomenclature and regular 
 * upper-snake-case
 * pattern
 
-## configuration
+## Configuration
 
-To enable naming style checking, you need to add configuration in settings:
+To enable naming style checking, you need to add the following configuration in the settings:
 ```json
 "emmylua.lint.nameStyle": true
 ```
@@ -81,7 +81,9 @@ Regular expressions support capture groups and then match basic nomenclature:
 
 Where `"$1": "camel_case"` means that the content of the first capture group needs to match the `camel_case` nomenclature
 
-* Supports mixed arrays of table structures and strings For example:
+* Supports mixed arrays of table structures and strings
+
+For example:
 
 ```json
 "local_name_style": [
@@ -94,4 +96,144 @@ Where `"$1": "camel_case"` means that the content of the first capture group nee
          "$1": "camel_case"
      }
 ]
+```
+
+## Examples for the configurable items
+
+The following list shows which elements each configurable item targets with a small code example, and lists the default configuration.
+
+### `local_name_style`
+
+> Default: `snake_case`
+
+Checked name in the following example is `result`. Note that
+`some_value` is checked by `module_local_name_style` because of its scope.
+
+```Lua
+local some_value = 42
+
+local function sum(first_value, second_value)
+    local result = first_value + second_value
+    return result
+end
+```
+
+### `function_param_name_style`
+
+> Default: `snake_case`
+
+Checked names in the following example are `first_value` and `second_value`.
+
+```Lua
+local function sum(first_value, second_value)
+    local result = first_value + second_value
+    return result
+end
+```
+
+### `function_name_style`
+
+> Default: `snake_case`
+
+Checked name in the following example is `some_action`.
+
+```Lua
+function some_action() 
+    return 0
+end
+```
+
+### `local_function_name_style`
+
+> Default: `snake_case`
+
+Checked name in the following example is `calculate_square`.
+
+```Lua
+local function calculate_square(x)
+  return x * x
+end
+```
+
+### `table_field_name_style`
+
+> Default: `snake_case`
+
+Checked names in the following example are `first_name` and `last_name`.
+
+```Lua
+local person = {}
+person.first_name = "John"
+person.last_name = "Doe"
+```
+
+### `global_variable_name_style`
+
+> Default: `snake_case` and `upper_snake_case`
+
+Checked name in the following example is `MAX_ELEMENTS`.
+
+```Lua
+MAX_ELEMENTS = 100
+```
+
+### `module_name_style`
+
+> Default: `snake_case`
+
+Checked name in the following example is `my_module`.
+
+```Lua
+local my_module = {}
+
+-- [...]
+
+return my_module
+```
+
+### `require_module_name_style`
+
+> Default: `snake_case` and `pascal_case`
+
+Checked name in the following example is `util_module`.
+
+```Lua
+local util_module = require("util_module")
+local data_module = import("data_module")
+```
+
+### `class_name_style`
+
+> Default: `snake_case` and `pascal_case`
+
+Checked name in the following example is `person`.
+
+```Lua
+local person = Class()
+```
+
+### `const_variable_name_style`
+
+> Default: `snake_case` and `upper_snake_case`
+
+Checked name in the following example is `PI`.
+
+```Lua
+local PI <const> = 3.14
+```
+
+### `module_local_name_style`
+
+> Default: Fallback on current `local_name_style` configuration
+
+Checked names in the following example are `some_value` and `data`.
+
+```Lua
+local some_value = 42
+local data = {}
+
+local function sum(first_value, second_value)
+    local result = first_value + second_value
+    return result
+end
 ```


### PR DESCRIPTION
This PR adds more information about all the name style rules to the documentation.

I've had multiple instances of needing to clarify which rule applies to what kind of code to colleagues, again in the last few days, so I've now collected smaller examples to highlight and explain what each rule/configuration item does and what its default value is.

I'm absolutely okay with a different format, if you prefer, but it would be very convenient to have this kind of information in the name style docs.

The Chinese translation, again, was generated using ChatGPT (and thus may contain errors in the texts).