### PR TITLE
Add documentation to lua.template.editorconfig

### DIFF
--- a/lua.template.editorconfig
+++ b/lua.template.editorconfig
@@ -101,6 +101,7 @@ align_call_args = false
 
 align_function_params = true
 
+# false or always
 align_continuous_assign_statement = true
 
 align_continuous_rect_table_field = true

--- a/lua.template.editorconfig
+++ b/lua.template.editorconfig
@@ -101,7 +101,7 @@ align_call_args = false
 
 align_function_params = true
 
-# false or always
+# true/false or always
 align_continuous_assign_statement = true
 
 align_continuous_rect_table_field = true


### PR DESCRIPTION
Added (possibly incomplete) documentation about valid values for align_continuous_assign_statement, derived from: https://github.com/LuaLS/lua-language-server/issues/2995

```
# false or always
align_continuous_assign_statement = true
```