### PR TITLE
Fix build with GCC 15

### DIFF
--- a/Util/include/Util/SymSpell/SymSpell.h
+++ b/Util/include/Util/SymSpell/SymSpell.h
@@ -24,8 +24,8 @@
 #include "EditDistance.h"
 #include "SuggestItem.h"
 #include <map>
-#include <string>
-#include <string_view>
+#include <cstddef>
+#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
Building with GCC 15 results in

In file included from Util/src/SymSpell/SymSpell.cpp:1: Util/include/Util/SymSpell/SymSpell.h:72:5: error: ‘uint32_t’ does not name a type
   72 |     uint32_t _compactMask;
      |     ^~~~~~~~
Util/include/Util/SymSpell/SymSpell.h:32:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by add
ing ‘#include <cstdint>’
   31 | #include <vector>
  +++ |+#include <cstdint>
   32 |

Caught while building lua-language-server with GCC 15 Fix taken from 234c0c8