### PR TITLE
Add the disable-next-line instruction to disable formatting for the next line

### DIFF
--- a/CodeFormatCore/src/Format/Analyzer/FormatDocAnalyze.cpp
+++ b/CodeFormatCore/src/Format/Analyzer/FormatDocAnalyze.cpp
@@ -106,6 +106,27 @@ void FormatDocAnalyze::AnalyzeDocFormat(LuaSyntaxNode n, FormatState &f, const L
                         }
 
                         break;
+                    } else if (action == "disable-next-line") {
+                        const std::size_t ignoreLine = n.GetStartLine(t) + 1;
+                        auto isIgnore = [&] (const LuaSyntaxNode node) -> bool {
+                            return !node.IsNull(t) && node.GetStartLine(t) == ignoreLine;
+                        };
+
+                        auto endNode = n.GetNextSibling(t);
+                        while (isIgnore(endNode)) {
+                            if (endNode.GetEndLine(t) > ignoreLine) {
+                                endNode = endNode.GetFirstChild(t);
+                            } else if (const auto next = endNode.GetNextSibling(t); isIgnore(next)) {
+                                endNode.ToNext(t);
+                            } else {
+                                break;
+                            }
+                        }
+
+                        if (!endNode.IsNull(t)) {
+                            AddIgnoreRange(IndexRange(n.GetIndex(), endNode.GetIndex()), t);
+                        }
+                        break;
                     } else if (action == "on") {
                         state = ParseState::List;
                         // todo

--- a/CodeFormatCore/src/Format/FormatState.cpp
+++ b/CodeFormatCore/src/Format/FormatState.cpp
@@ -156,19 +156,18 @@ void FormatState::DfsForeach(std::vector<LuaSyntaxNode> &startNodes,
         resolve.Reset();
         if (traverse.Event == TraverseEvent::Enter) {
             traverseStack.back().Event = TraverseEvent::Exit;
-            if (_ignoreRange.EndIndex != 0) {
-                auto index = traverse.Node.GetIndex();
-                if (index >= _ignoreRange.StartIndex && index <= _ignoreRange.EndIndex) {
-                    continue;
-                }
-            }
-            for (auto &analyzer: _analyzers) {
-                analyzer->Query(*this, traverse.Node, t, resolve);
-            }
+
+            // We need to first add all child nodes to the traversal list.
             auto children = traverse.Node.GetChildren(t);
             // 不采用 <range>
             for (auto rIt = children.rbegin(); rIt != children.rend(); rIt++) {
                 traverseStack.emplace_back(*rIt, TraverseEvent::Enter);
+            }
+
+            // For the code that has already been ignored, we also need to
+            // analyze it to determine how to indent next.
+            for (auto &analyzer: _analyzers) {
+                analyzer->Query(*this, traverse.Node, t, resolve);
             }
 
             if (resolve.GetIndentStrategy() != IndentStrategy::None) {
@@ -201,6 +200,16 @@ void FormatState::DfsForeach(std::vector<LuaSyntaxNode> &startNodes,
                     default: {
                         break;
                     }
+                }
+            }
+
+            // Skip the nodes that need to be ignored. Since the range of ignoring starts
+            // from the @format node, we need to execute enterHandle once when entering
+            // the ignore range to output all the ignored content.
+            if (_ignoreRange.EndIndex != 0) {
+                auto index = traverse.Node.GetIndex();
+                if (index > _ignoreRange.StartIndex && index <= _ignoreRange.EndIndex) {
+                    continue;
                 }
             }
 

--- a/Test/src/FormatResult_unitest.cpp
+++ b/Test/src/FormatResult_unitest.cpp
@@ -892,6 +892,76 @@ local t = {
     gjopepgo = 123,
 }
 )"));
+
+    EXPECT_TRUE(TestHelper::TestFormatted(
+        R"(
+local t = {
+    ---@format disable-next-line
+    foo =  123, bar  = 234,
+    baz =  345,
+}
+)",
+        R"(
+local t = {
+    ---@format disable-next-line
+    foo =  123, bar  = 234,
+    baz = 345,
+}
+)"));
+
+    EXPECT_TRUE(TestHelper::TestFormatted(
+    R"(
+local t = {
+    ---@format disable-next-line
+    foo =   function( a,  b )
+        return  {
+            foo =   a,
+            bar =  b,
+        }
+    end,
+    bar =  1,
+}
+)",
+    R"(
+local t = {
+    ---@format disable-next-line
+    foo =   function( a,  b )
+        return {
+            foo = a,
+            bar = b,
+        }
+    end,
+    bar = 1,
+}
+)"));
+
+    EXPECT_TRUE(TestHelper::TestFormatted(
+    R"(
+local t = {
+    ---@format disable-next-line
+    foo =   function( a,  b )
+        return  {
+            foo =   a,
+            bar =  b,
+        }
+    end,
+    bar =  1,
+}
+---@format disable-next-line
+)",
+    R"(
+local t = {
+    ---@format disable-next-line
+    foo =   function( a,  b )
+        return {
+            foo = a,
+            bar = b,
+        }
+    end,
+    bar = 1,
+}
+---@format disable-next-line
+)"));
 }
 
 TEST(Format, feature_102) {


### PR DESCRIPTION
This PR introduces a new formatting instruction `---@format disable-next-line`.

When there are too many statements on a single line or it is a large code block, `---@format disable-next` may not meet the requirements, for example, the following code:
```lua
return {
    ---@format disable-next
    foo =  1, bar =  2, -- after formatting, it will become `foo = 1,bar = 2`.

    ---@format disable-next
    config = function( opts )
        -- The function body will not be formatted.
        return {
            foo =  1,
            bar =  2,
        }
    end,
}
```